### PR TITLE
Add support for enable/disable on fragments of the current page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When using the [Laravel-markdown](https://github.com/spatie/laravel-markdown/) p
 
 ### Choosing which links to enhance
 
-By default, the extension will add `wire:navigate` to all internal links. To know which link is internal, you must specify your application's base URL.
+By default, the extension will add `wire:navigate` to all internal links except fragments of the current page. To know which link is internal, you must specify your application's base URL.
 
 ```php
 $converter = new CommonMarkConverter($environment);
@@ -106,6 +106,15 @@ $converter->getEnvironment()->addExtension(new WireNavigateExtension(
     baseUrl: 'https://example.app',
     enabled: fn (string $url) => preg_match('/\/docs\//', $url),
     hover: true, 
+));
+```
+
+Enable on fragments of the current page:
+
+```php
+$converter = new CommonMarkConverter($environment);
+$converter->getEnvironment()->addExtension(new WireNavigateExtension(
+    fragment: true, 
 ));
 ```
 

--- a/src/ShouldWireNavigate.php
+++ b/src/ShouldWireNavigate.php
@@ -21,12 +21,12 @@ class ShouldWireNavigate
 
     public function __invoke(string $url): bool
     {
-        $url = Url::fromString($url);
-
         // Ensure same page fragment match
-        if ($url->getPath() === '/' && !empty($url->getFragment())) {
+        if (str_starts_with($url, '#')) {
             return $this->fragment;
         }
+
+        $url = Url::fromString($url);
 
         // Ensure hosts match
         if ($url->getHost()) {

--- a/src/ShouldWireNavigate.php
+++ b/src/ShouldWireNavigate.php
@@ -12,6 +12,7 @@ class ShouldWireNavigate
     public function __construct(
         protected string $domain = '',
         protected ?array $paths = null,
+        protected bool $fragment = false,
     ) {
         $this->baseUrl = $domain
             ? Url::fromString(preg_match('/^https?:\/\//', $domain) ? $domain : ('https://'.$domain))
@@ -21,6 +22,11 @@ class ShouldWireNavigate
     public function __invoke(string $url): bool
     {
         $url = Url::fromString($url);
+
+        // Ensure same page fragment match
+        if ($url->getPath() === '/' && !empty($url->getFragment())) {
+            return $this->fragment;
+        }
 
         // Ensure hosts match
         if ($url->getHost()) {

--- a/src/WireNavigateExtension.php
+++ b/src/WireNavigateExtension.php
@@ -38,6 +38,7 @@ class WireNavigateExtension implements ConfigurableExtensionInterface, Configura
         $this->shouldWireNavigate ??= new ShouldWireNavigate(
             domain: $this->configuration->get('wire_navigate/domain'),
             paths: $this->configuration->get('wire_navigate/paths'),
+            fragment: $this->configuration->get('wire_navigate/fragment'),
         );
 
         $this->attribute ??= $this->configuration->get('wire_navigate/hover')
@@ -70,6 +71,7 @@ class WireNavigateExtension implements ConfigurableExtensionInterface, Configura
             'domain' => Expect::string(''),
             'paths' => Expect::anyOf(Expect::null(), Expect::arrayOf(Expect::string()))->default(null),
             'hover' => Expect::bool(false),
+            'fragment' => Expect::bool(false),
         ]));
     }
 }

--- a/tests/ShouldWireNavigateTest.php
+++ b/tests/ShouldWireNavigateTest.php
@@ -35,3 +35,39 @@ it('is enabled on links matching a path when an array of paths are provided', fu
 
     expect($shouldWireNavigate('/docs-and-more'))->toBe(false);
 });
+
+it('is disabled on links on the same page when fragment is disabled (default)', function () {
+    $shouldWireNavigate = new ShouldWireNavigate();
+
+    expect($shouldWireNavigate('#example'))->toBe(false);
+});
+
+it('is enabled on links on the same page when fragment is enabled', function () {
+    $shouldWireNavigate = new ShouldWireNavigate(fragment: true);
+
+    expect($shouldWireNavigate('#example'))->toBe(true);
+});
+
+it('is enabled on links on the same domain or without a domain when fragment is disabled (default) when no base URL is provided', function () {
+    $shouldWireNavigate = new ShouldWireNavigate();
+
+    expect($shouldWireNavigate('/#example'))->toBe(true);
+    expect($shouldWireNavigate('/about#example'))->toBe(true);
+
+    expect($shouldWireNavigate('https://example.app#example'))->toBe(false);
+    expect($shouldWireNavigate('https://example.app/about#example'))->toBe(false);
+});
+
+it('is enabled on links on the same page, domain, or without a domain when fragment is enabled and when a base URL is provided', function (string $domain) {
+    $shouldWireNavigate = new ShouldWireNavigate(domain: $domain, fragment: true);
+
+    expect($shouldWireNavigate('#example'))->toBe(true);
+    expect($shouldWireNavigate('/#example'))->toBe(true);
+    expect($shouldWireNavigate('/about#example'))->toBe(true);
+
+    expect($shouldWireNavigate('https://example.app#example'))->toBe(true);
+    expect($shouldWireNavigate('https://example.app/about#example'))->toBe(true);
+
+    expect($shouldWireNavigate('https://another.app#example'))->toBe(false);
+    expect($shouldWireNavigate('https://another.app/about#example'))->toBe(false);
+})->with(['https://example.app', 'example.app']);

--- a/tests/WireNavigateExtensionTest.php
+++ b/tests/WireNavigateExtensionTest.php
@@ -55,3 +55,23 @@ it('adds wire:navigate to links with path configuration', function () {
     expect(trim($converter->convert('[Installation](/docs/installation)')->getContent()))
         ->toBe('<p><a wire:navigate href="/docs/installation">Installation</a></p>');
 });
+
+it('does not add wire:navigate.hover on the same page when fragment is disabled (default)', function () {
+    $converter = new CommonMarkConverter();
+    $converter->getEnvironment()->addExtension(new WireNavigateExtension());
+
+    expect(trim($converter->convert('[Example Fragment](#example)')->getContent()))
+        ->toBe('<p><a href="#example">Example Fragment</a></p>');
+});
+
+it('adds wire:navigate.hover on the same page when fragment is enabled', function () {
+    $converter = new CommonMarkConverter([
+        'wire_navigate' => [
+            'fragment' => true,
+        ],
+    ]);
+    $converter->getEnvironment()->addExtension(new WireNavigateExtension());
+
+    expect(trim($converter->convert('[Example Fragment](#example)')->getContent()))
+        ->toBe('<p><a wire:navigate href="#example">Example Fragment</a></p>');
+});


### PR DESCRIPTION
In the current implementation `wire;navigate` is added to all internal links. When the link is a fragment of current page, _e.g._, `#example` the page should just scroll to the fragment instead of navigating.

The default is `false` (disabled) and it can be enabled via the settings or constructor like any other option of this library.

